### PR TITLE
Added envify transform

### DIFF
--- a/.npm/plugin/cosmosBrowserify/npm-shrinkwrap.json
+++ b/.npm/plugin/cosmosBrowserify/npm-shrinkwrap.json
@@ -645,6 +645,33 @@
           "version": "3.0.0"
         }
       }
+    },
+    "envify": {
+      "version": "3.4.0",
+      "dependencies": {
+        "through": {
+          "version": "2.3.7"
+        },
+        "jstransform": {
+          "version": "10.1.0",
+          "dependencies": {
+            "base62": {
+              "version": "0.1.1"
+            },
+            "esprima-fb": {
+              "version": "13001.1001.0-dev-harmony-fb"
+            },
+            "source-map": {
+              "version": "0.1.31",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/package.js
+++ b/package.js
@@ -11,7 +11,7 @@ Package.registerBuildPlugin({
   // need 'meteor' for Npm and Meteor.wrapAsync
   use: ['coffeescript@1.0.6','meteor'],
   sources: ['plugin/browserify.coffee'],
-  npmDependencies: {"browserify": "9.0.8"}
+  npmDependencies: {"browserify": "9.0.8", "envify": "3.4.0"}
 });
 
 Package.onTest(function(api) {

--- a/plugin/browserify.coffee
+++ b/plugin/browserify.coffee
@@ -1,4 +1,5 @@
 Browserify = Npm.require 'browserify'
+envify = Npm.require 'envify'
 
 # get 'stream' to use PassThrough to provide a Buffer as a Readable stream
 stream     = Npm.require 'stream'
@@ -11,6 +12,10 @@ processFile = (step) ->
     # browserify options
     basedir: getBasedir(step) # Browserify looks here for npm modules
     debug: getDebug(step)     # Browserify creates internal source map
+
+  # use the envify transform to replace instances of `process.env`
+  # with strings
+  browserify.transform envify
 
   # have browserify process the file and include all required modules.
   # we receive a readable stream as the result


### PR DESCRIPTION
Sparked by https://github.com/grovelabs/meteor-react/issues/11, adding in an [`envify`](https://www.npmjs.com/package/envify) transform to the browserify build process enables dead code to be eliminated in production versions of some libraries like React. envify replaces the `process.env` calls with the string values set in the running process, and then UglifyJS, which Meteor runs automatically, eliminates any sections that are dead as a result.

I'm not aware of any downsides by replacing all instances of `process.env.XXX` unless there happened to be a malicious library that called something like `process.env.AWS_SECRET_KEY` and that got inserted and exposed on the client. That gets tricky if there's a nested dependency doing something fishy. But I don't think that'll be a problem.
