### PR TITLE
Add support for app.browserify.options.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
     2. [Create App browserify file](#2-create-app-browserify-file)
     3. [Enable browserify](#3-enable-browserify)
     4. [Verify success](#4-verify-it-worked)
+4. [Passing options to Browserify](#passing-options-to-browserify)
+    5. [Using transforms](#using-transforms)
 
 ## Example Meteor App
 
@@ -169,5 +171,51 @@ It will browserify your `app.browserify.js` file and push it to the client.
 
 In your browser's JavaScript console you can use the variable (`uppercase` if you followed my example).
 
+## Passing options to Browserify
+
+Browserify can be configured with additional options by adding a file with the same name as your `.browserify.js` file, but with the extension `.browserify.options.js`.
+
+```
+# example file structure:
+- app.browserify.js           # entry point
+- app.browserify.options.js   # options
+```
+
+You can use any [options that you can pass to the API](https://github.com/substack/node-browserify#browserifyfiles--opts).
+
+#### Using transforms
+
+To use a Browserify transform from NPM, add its package to your `packages.json` as described above; then pass it in the special `transform` option. This option is an object where the keys are the transform names, and the values are the options that can be passed to that transform.
+
+Below is an example of using the `exposify` transform to use a global React variable with React Router instead of the React package from NPM.
+
+##### packages.json
+
+```
+{
+  "react-router": "0.13.3",
+  "exposify": "0.4.3"
+}
+```
+##### app.browserify.js
+
+```js
+ReactRouter = require("react-router");
+```
+
+##### app.browserify.options.json
+
+```js
+{
+  "transforms": {
+    "exposify": {
+      "global": true,
+      "expose": {
+        "react": "React"
+      }
+    }
+  }
+}
+```
 
 ## MIT License

--- a/package.js
+++ b/package.js
@@ -9,7 +9,7 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "CosmosBrowserify",
   // need 'meteor' for Npm and Meteor.wrapAsync
-  use: ['coffeescript@1.0.6','meteor'],
+  use: ['coffeescript@1.0.6', 'meteor', 'underscore'],
   sources: ['plugin/browserify.coffee'],
   npmDependencies: {"browserify": "9.0.8", "envify": "3.4.0"}
 });
@@ -17,7 +17,7 @@ Package.registerBuildPlugin({
 Package.onTest(function(api) {
   api.use('tinytest');
   // not testing by adding package in 'use'
-  api.use('coffeescript@1.0.6');
+  api.use(['coffeescript@1.0.6', 'underscore']);
   api.addFiles([
     // export stuff for use in Testing, and to Mock things like Npm
     //'test/export.js',

--- a/test/mocks.coffee
+++ b/test/mocks.coffee
@@ -66,6 +66,10 @@ required =
       transform: (envify) -> Result.envify.transformed = true
     }
 
+  fs:
+    existsSync: -> false
+    readFileSync: -> null
+
 # mock this by returning our mock objects instead
 @Npm =
   require: (name) -> required[name]
@@ -94,7 +98,9 @@ required =
     return step
 
   # mock this function and get our plugin function to call
-  registerSourceHandler: (extension, fn) -> Plugin.fn = fn
+  registerSourceHandler: (extension, fn) ->
+    if extension is "browserify.js"
+      Plugin.fn = fn
 
 # don't use @Meteor as with other Mocks because `Meteor` exists in test client
 # instead, replace the wrapAsync with our version, which seems not to affect


### PR DESCRIPTION
You can now create a file to pass options to browserify, including transforms. The transforms can be loaded from NPM in the same way as other dependencies.

It's going to be used in the new React in Meteor guide, preview here: http://react-in-meteor.readthedocs.org/en/latest/client-npm/
### TODO
- [x] write documentation for this new feature
- [x] squash commits
